### PR TITLE
Quick and dirty fix for timeouts with chains longer than 3

### DIFF
--- a/tlsver.c
+++ b/tlsver.c
@@ -581,7 +581,7 @@ static struct tlsver_numstring tlsver_alerts[] = {
 //
 
 #define TLSVER_MAX_TEST_DESTINATIONS			 100
-#define TLSVER_MAXMSGSIZE				5000
+#define TLSVER_MAXMSGSIZE			       16384
 #define TLSVER_MAXWAIT_USECS		   (5 * 1000 * 1000)
 #define TLSVER_MAXWAIT_CONNECT_SECS			   5
 


### PR DESCRIPTION
-- such as downforeveryoneorjustme.com:

```
nostromo:tlsver ximaera$ openssl s_client -connect downforeveryoneorjustme.com:443 2>&1 <<<'' | grep \ s:
 0 s:/CN=downforeveryoneorjustme.com
 1 s:/C=US/O=Amazon/OU=Server CA 1B/CN=Amazon
 2 s:/C=US/O=Amazon/CN=Amazon Root CA 1
 3 s:/C=US/ST=Arizona/L=Scottsdale/O=Starfield Technologies, Inc./CN=Starfield Services Root Certificate Authority - G2
nostromo:tlsver ximaera$ git checkout master >/dev/null 2>&1
nostromo:tlsver ximaera$ make
cc -g -c tlsver.c
cc -g tlsver.o -o tlsver
nostromo:tlsver ximaera$ ./tlsver downforeveryoneorjustme.com
tlsver: error: timed out -- exit
nostromo:tlsver ximaera$ git checkout fix_timeout >/dev/null 2>&1
nostromo:tlsver ximaera$ make
cc -g -c tlsver.c
cc -g tlsver.o -o tlsver
nostromo:tlsver ximaera$ ./tlsver downforeveryoneorjustme.com
1.2
nostromo:tlsver ximaera$
```